### PR TITLE
Fix for Sublime Text 3

### DIFF
--- a/scroll_offset.py
+++ b/scroll_offset.py
@@ -10,7 +10,7 @@ import sublime_plugin
 try:
 	import mouse_event_listener
 except:
-	print "ScrollOffset: Install Mouse Event Listener (https://github.com/SublimeText/MouseEventListener) to ignore mouse clicks!"
+	print("ScrollOffset: Install Mouse Event Listener (https://github.com/SublimeText/MouseEventListener) to ignore mouse clicks!")
 
 def num_visible_rows_in_view(view):
 	vr = view.visible_region()


### PR DESCRIPTION
Without any extras.
Worked for me in Build 3047 on Mac OS X.
The error was displayed in SB3 console _Syntax Error_.
